### PR TITLE
Fixed padding/conversion bug

### DIFF
--- a/mmll.py
+++ b/mmll.py
@@ -88,7 +88,7 @@ def parselogdata(config, logdata, starttime):
       byteconv = ""
       # Read bytes in reverse order.
       for j in range(len(bytes)):
-         byteconv = hex(bytes[j])[2:].ljust(2,'0') + byteconv 
+         byteconv = hex(bytes[j])[2:].rjust(2,'0') + byteconv 
          internal = int('0x'+byteconv, 16)
       
       # bitmask code eeds tested


### PR DESCRIPTION
Fixed a bug in parselogdata() that corrupted single-digit (0-F) replies in logged bytes.